### PR TITLE
Add dynamic backend, closest to the origin, cache-status

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -1,14 +1,16 @@
 # Full app config reference: https://fly.io/docs/reference/configuration/
-app = "cdn-2024-01-26"
-# Closest to James
-primary_region = "sjc"
-# Secondary region will be "lhr", closest to Gerhard
+app = "cdn-2024-08-02"
+# Closest to the origin
+primary_region = "iad"
 
 kill_signal = "SIGTERM"
 kill_timeout = 30
 
 [env]
-VARNISH_SIZE="500M"
+# We want a low value so that:
+# - we leave room for "sidecar" processes (log drains, purge worker, etc.)
+# - easier to test what happens when the memory fills up
+VARNISH_SIZE="100M"
 
 [[vm]]
 size = "shared-cpu-1x"
@@ -25,9 +27,9 @@ protocol = "tcp"
 grace_period = "5s"
 interval = "5s"
 method = "get"
-path = "/varnish_status"
+path = "/varnish_health"
 protocol = "http"
-timeout = "4s"
+timeout = "3s"
 
 [[services.ports]]
 handlers = ["tls", "http"]


### PR DESCRIPTION
This is how serving <https://pipedream.changelog.com> requests:

https://github.com/user-attachments/assets/4de66cb3-1ff9-4891-8e35-6aea5b024211

This is the second iteration which:
- uses dynamic backends
- places the initial instance closest to the origin
- improves on the x-cache header via cache-status

We also made the `VARNISH_SIZE` smaller so that it fits the default instance size. We are leaving room for "sidecar" processes (log drains, purge worker, etc.) and also for testing what happens when the memory fills up.

We did this together with James A Rosen & Matt Johnson on August 2, 2024. Will add the recording when it's public. It's a follow-up to:
- https://github.com/thechangelog/changelog.com/pull/518

We also talked about this in a YouTube Live Stream with Peter Mbanugo: https://www.youtube.com/live/ghE59eB465I

[![tech-with-peter](https://github.com/user-attachments/assets/2031a8e5-846f-47b9-a0a7-01e4462420ee)](https://www.youtube.com/live/ghE59eB465I)