### PR TITLE
Add tests

### DIFF
--- a/.github/workflows/_github.yml
+++ b/.github/workflows/_github.yml
@@ -1,0 +1,21 @@
+name: GitHub
+
+on:
+  workflow_call:
+
+jobs:
+  run:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: "Checkout code..."
+        uses: actions/checkout@v4
+
+      - uses: extractions/setup-just@v2
+        with:
+          just-version: "1.37.0"
+
+      - name: "Test..."
+        run: |
+          just test --verbose
+        env:
+          TERM: xterm

--- a/.github/workflows/_namespace.yml
+++ b/.github/workflows/_namespace.yml
@@ -1,0 +1,22 @@
+name: Namespace.so
+
+on:
+  workflow_call:
+
+jobs:
+  run:
+    runs-on:
+      - nscloud-ubuntu-24.04-amd64-2x4
+    steps:
+      - name: "Checkout code..."
+        uses: namespacelabs/nscloud-checkout-action@v5
+
+      - uses: extractions/setup-just@v2
+        with:
+          just-version: "1.37.0"
+
+      - name: "Test..."
+        run: |
+          just test --verbose
+        env:
+          TERM: xterm

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+# All jobs have the same outcome. We define multiple for resiliency reasons.
+jobs:
+  # In thechangelog/pipedream repository (a.k.a. upstream),
+  # this is the preferred default (i.e. custom runners, faster than GitHub):
+  on-namespace:
+    if: ${{ contains(vars.RUNS_ON, 'namespace') }}
+    uses: ./.github/workflows/_namespace.yml
+    secrets: inherit
+
+  # Just in case Namespace.so misbehaves, we want a fallback.
+  # Always run two of everything™
+  on-github-fallback:
+    needs: on-namespace
+    if: ${{ failure() }}
+    uses: ./.github/workflows/_github.yml
+    secrets: inherit
+
+  # As forks will not have access to our Namespace.so custom runners,
+  # we fallback to the default GitHub free runners:
+  on-github:
+    if: ${{ !contains(vars.RUNS_ON, 'namespace') }}
+    uses: ./.github/workflows/_github.yml
+    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ You are welcome to fork it and make it your own. OSS FTW 💚
 ## How is it going (a.k.a. Roadmap)
 
 - [x] Static backend, 1 day stale, stale on error, x-headers - `46` lines of VCL - [Initial commit](https://github.com/thechangelog/pipedream/commit/17d3899a52d9dc887efd7f49de92b24249431234)
-- [x] Dynamic backend, cache-status header - `60` lines of VCL - [PR #1](https://github.com/thechangelog/pipedream/commit/12086a1e98b10aaf057becf645218344e4b74cd6)
-- [ ] Test harness
-- [ ] Add Feeds backend: /feed -> https://feeds.changelog.place/feed.xml
+- [x] Dynamic backend, cache-status header - `60` lines of VCL - [PR #1](https://github.com/thechangelog/pipedream/pull/1)
+- [x] Add tests - `60` lines of VCL - [PR #3](https://github.com/thechangelog/pipedream/pull/3)
+- [ ] Add feeds backend: /feed -> http://feeds.changelog.place/feed.xml
 - [ ] Send logs to Honeycomb.io (same structure as Fastly logs)
 - [ ] Send logs to S3 (for stats)
 - [ ] Implement purge across all app instances (Fly.io machines)
@@ -43,5 +43,5 @@ See you in our Slack 👋 join from <https://changelog.com/~> (requires signing 
 
 ## Contributors
 
-- [James A Rosen](https://www.jamesarosen.com/), Staff Engineer
+- [James A Rosen](https://www.jamesarosen.com/now), Staff Engineer
 - [Matt Johnson](https://github.com/mttjohnson), Senior Site Reliability Engineer

--- a/justfile
+++ b/justfile
@@ -1,0 +1,58 @@
+# vim: set tabstop=4 shiftwidth=4 expandtab:
+
+[private]
+default:
+    just --list
+
+[private]
+fmt:
+    just --fmt --check --unstable
+
+OS := if os() == "macos" { "apple" } else { "unknown" }
+OS_ALT := if os() == "macos" { "darwin" } else { "linux-gnu" }
+LOCAL_PATH := home_dir() / ".local"
+BIN_PATH := LOCAL_PATH / "bin"
+
+# https://github.com/Orange-OpenSource/hurl/releases
+
+HURL_VERSION := "5.0.1"
+HURL_NAME := "hurl-" + HURL_VERSION + "-" + arch() + "-" + OS + "-" + OS_ALT
+HURL := LOCAL_PATH / HURL_NAME / "bin" / "hurl"
+
+[private]
+hurl *ARGS:
+    @[ -e {{ HURL }} ] \
+    || (echo {{ _GREEN }}🔀 Installing hurl {{ HURL_VERSION }} ...{{ _RESET }} \
+        && mkdir -p {{ BIN_PATH }} \
+        && (curl -LSsf "https://github.com/Orange-OpenSource/hurl/releases/download/{{ HURL_VERSION }}/{{ HURL_NAME }}.tar.gz" | tar zxv -C {{ LOCAL_PATH }}) \
+        && chmod +x {{ HURL }} && echo {{ _MAGENTA }}{{ HURL }} {{ _RESET }} && {{ HURL }} --version \
+        && ln -sf {{ HURL }} {{ BIN_PATH }}/hurl && echo {{ _MAGENTA }}hurl{{ _RESET }} && hurl --version)
+    {{ if ARGS != "" { HURL + " " + ARGS } else { HURL + " --help" } }}
+
+# Run the tests
+test *ARGS: (hurl "--test --color --report-html tmp --variable host=https://pipedream.changelog.com " + ARGS + " test/*.hurl")
+
+# Open the test report
+report:
+    open tmp/index.html
+
+# https://linux.101hacks.com/ps1-examples/prompt-color-using-tput/
+
+_BOLD := "$(tput bold)"
+_RESET := "$(tput sgr0)"
+_BLACK := "$(tput bold)$(tput setaf 0)"
+_RED := "$(tput bold)$(tput setaf 1)"
+_GREEN := "$(tput bold)$(tput setaf 2)"
+_YELLOW := "$(tput bold)$(tput setaf 3)"
+_BLUE := "$(tput bold)$(tput setaf 4)"
+_MAGENTA := "$(tput bold)$(tput setaf 5)"
+_CYAN := "$(tput bold)$(tput setaf 6)"
+_WHITE := "$(tput bold)$(tput setaf 7)"
+_BLACKB := "$(tput bold)$(tput setab 0)"
+_REDB := "$(tput setab 1)$(tput setaf 0)"
+_GREENB := "$(tput setab 2)$(tput setaf 0)"
+_YELLOWB := "$(tput setab 3)$(tput setaf 0)"
+_BLUEB := "$(tput setab 4)$(tput setaf 0)"
+_MAGENTAB := "$(tput setab 5)$(tput setaf 0)"
+_CYANB := "$(tput setab 6)$(tput setaf 0)"
+_WHITEB := "$(tput setab 7)$(tput setaf 0)"

--- a/test/admin.hurl
+++ b/test/admin.hurl
@@ -1,0 +1,12 @@
+# Get the admin homepage
+GET {{host}}/admin
+[Options]
+repeat: 2 # repeat so that we confirm caching behaviour
+HTTP/2 302 # expect found redirect via HTTP/2
+[Asserts]
+duration < 1000 # ensure that it loads sub 1s - GitHub Actions networking can be slow...
+header "location" == "/" # redirect to homepage
+header "x-varnish" exists # served by Varnish
+header "age" == "0" # NOT stored in cache
+header "cache-status" contains "hits=0" # double-check that it's NOT stored in cache
+header "cache-status" contains "miss" # NOT served from cache

--- a/test/feed.hurl
+++ b/test/feed.hurl
@@ -1,0 +1,33 @@
+# Get the changelog feed
+GET {{host}}/podcast/feed
+HTTP/2 200 # expect OK response via HTTP/2
+[Asserts]
+duration < 5000 # ensure that it loads sub 5s - GitHub Actions networking can be slow...
+header "x-varnish" exists # served by Varnish
+header "age" exists # cache age works
+header "cache-status" contains "Edge" # served by an edge cache location
+header "cache-status" contains "ttl=" # ttl is set
+header "cache-status" contains "grace=" # grace is set
+header "cache-status" contains "region=" # region that served this request 
+
+# Get the changelog feed AGAIN
+GET {{host}}/podcast/feed
+[Options]
+delay: 65s # wait >60s so that it becomes stale
+HTTP/2 200 # expect OK response via HTTP/2
+[Asserts]
+duration < 2000 # ensure that it loads sub 2s when cached
+header "cache-status" contains "hit" # served from cache
+header "cache-status" contains "stale" # will need to be refreshed from origin
+header "age" toInt > 60 # has been stored in cache for MORE THAN 60s
+
+# Get the changelog feed ONE MORE TIME
+GET {{host}}/podcast/feed
+[Options]
+delay: 2s # wait a bit so that it refreshes from origin
+HTTP/2 200 # expect OK response via HTTP/2
+[Asserts]
+duration < 2000 # ensure that it loads sub 2s when cached
+header "cache-status" contains "hit" # served from cache
+header "cache-status" not contains "stale" # not stale
+header "age" toInt < 60 # has been stored in cache LESS THAN 60s

--- a/test/homepage.hurl
+++ b/test/homepage.hurl
@@ -1,0 +1,18 @@
+# Get the homepage
+GET {{host}}
+HTTP/2 200 # expect OK response via HTTP/2
+[Asserts]
+duration < 1000 # ensure that it loads sub 1s - GitHub Actions networking can be slow...
+header "x-varnish" exists # served by Varnish
+header "age" exists # cache age works
+header "cache-status" contains "Edge" # served by an edge cache location
+header "cache-status" contains "ttl=" # ttl is set
+header "cache-status" contains "grace=" # grace is set
+header "cache-status" contains "region=" # region that served this request 
+
+# Get the homepage AGAIN
+GET {{host}}
+HTTP/2 200 # expect OK response via HTTP/2
+[Asserts]
+duration < 200 # now that it is cached, ensure that it loads sub 200ms - GitHub Actions networking can be slow...
+header "cache-status" contains "hit" # definitely served from cache


### PR DESCRIPTION
So that we can continue building this out with confidence, "especially once we start adding those edge redirects and things..."

Run them in GitHub Actions on every change. Run them locally with:

    just test

View the test report:

    just report

There is one big issue with this. Can you spot it?

Closes #2

---

This uses <https://hurl.dev/>, a command line tool that runs HTTP requests defined in a simple plain text format.

[`Orange-OpenSource/hurl` 🤟](https://github.com/Orange-OpenSource/hurl)

<img width="1392" alt="Screenshot 2024-12-01 at 07 40 58" src="https://github.com/user-attachments/assets/c8343f0f-1bcd-4c30-adab-3b47cfc06c72">

---

## How to run this locally?

https://github.com/user-attachments/assets/088ab900-2609-4e08-a0a3-66bbe986fe5a