### PR TITLE
Bump the instance size to performance-1x with 8GB of RAM

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -7,13 +7,13 @@ kill_signal = "SIGTERM"
 kill_timeout = 30
 
 [env]
-# This leaves 33% headroom from the machine's total available memory
+# This leaves 20% headroom from the machine's total available memory
 # Any less than this and Varnish makes the machine crash due to OOM errors.
-VARNISH_SIZE = "2640M"
+VARNISH_SIZE = "6400M"
 
 [[vm]]
-size = "shared-cpu-4x"
-memory = "4GB"
+size = "performance-1x"
+memory = "8GB"
 
 [deploy]
 strategy = "bluegreen"


### PR DESCRIPTION
For better performance to handle the extra load and more memory for a higher cache hit ratios.

Not sure whether `VARNISH_SIZE` has the correct value, but let's try it and see how it behaves in practice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and cleanup for log processing, ensuring safer and more reliable operation.
* **Chores**
  * Increased allocated memory and switched to a performance-optimized instance for deployments, enhancing system capacity and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->