### PR TITLE
Add more locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ You are welcome to fork this and build your own - OSS FTW 💚
   - ✅ Handle varnish-json-response failing on startup - [PR #33](https://github.com/thechangelog/pipely/pull/33)
   - ✅ Bump the instance size to performance-1x with 8GB of RAM - [PR #34](https://github.com/thechangelog/pipely/pull/34)
   - Route 50% of the production traffic through
+- ☑️ Tag & ship `v1.0-rc.6`
+  - ✅ Add more locations - [PR #35](https://github.com/thechangelog/pipely/pull/35)
 - ☑️ Tag & ship `v1.0`
 - ☑️ Route 100% of the production traffic through `v1.0`
 

--- a/just/_config.just
+++ b/just/_config.just
@@ -34,7 +34,7 @@ FLY_APP := env("FLY_APP", "cdn-2025-02-25")
 FLY_APP_IMAGE := env("FLY_APP_IMAGE", "ghcr.io/thechangelog/pipely")
 
 [private]
-FLY_APP_REGIONS := env("FLY_APP_REGIONS", "sjc,dfw,ord,iad,scl,lhr,fra,jnb,sin,syd")
+FLY_APP_REGIONS := env("FLY_APP_REGIONS", "sea,sjc,lax,dfw,ord,iad,ewr,scl,lhr,cdg,ams,fra,jnb,sin,nrt,syd")
 
 [private]
 export PURGE_TOKEN := env("PURGE_TOKEN", "local-purge")


### PR DESCRIPTION
This brings the total of locations to 16 (up from 10).

We need to serve **a lot** of traffic in Europe, and this distributes it a bit more among 4 high-traffic locations:
1. Frankfurt
2. Amsterdam
3. Paris
4. London

We are also adding more capacity on the West coast (Seattle & Los Angeles), East coast (New Jersey) and also one more location in Asia: Tokyo.

This makes the entire system hum!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the roadmap in the README to include the new release candidate step v1.0-rc.6, with a completed task to add more locations.

* **Chores**
  * Expanded the default list of deployment regions for the app to include additional locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->