### PR TITLE
Force Fly.io Proxy to serve HTTP/1.1

### DIFF
--- a/.github/workflows/_github.yml
+++ b/.github/workflows/_github.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: extractions/setup-just@v3
         with:
-          just-version: '1.45.0'
+          just-version: '1.46.0'
 
       - name: 'Test all (including local acceptance)...'
         run: |

--- a/.github/workflows/_namespace.yml
+++ b/.github/workflows/_namespace.yml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: extractions/setup-just@v3
         with:
-          just-version: '1.45.0'
+          just-version: '1.46.0'
 
       - name: Setup cache
         uses: namespacelabs/nscloud-cache-action@v1

--- a/.github/workflows/check_all.yml
+++ b/.github/workflows/check_all.yml
@@ -1,9 +1,9 @@
 name: 'Check all instances'
 
 on:
-  # Run the workflow every 4 hours:
+  # Run the workflow every hour:
   schedule:
-    - cron: "23 */4 * * *"
+    - cron: "23 * * * *"
   # Verify that the workflow works as expected after changes
   push:
     paths:
@@ -26,7 +26,7 @@ jobs:
 
       - uses: extractions/setup-just@v3
         with:
-          just-version: '1.45.0'
+          just-version: '1.46.0'
 
       - name: Setup cache
         uses: namespacelabs/nscloud-cache-action@v1
@@ -40,7 +40,7 @@ jobs:
           just check-all \
           || just check-all
 
-      - name: 'Check all instances HTTP/2 ...'
+      - name: 'Check all instances HTTP/2 → ALPN forces HTTP/1.1 ...'
         run: |
           just hurl --version
           just check-all 2 \

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ You are welcome to fork this and build your own - OSS FTW 💚
   - ✅ Log `app_generation` - [PR #52](https://github.com/thechangelog/pipely/pull/52)
 - Tag & ship `v1.3`
   - ✅ Run periodic HTTP/1.1 checks (on top of HTTP/2) - [PR #53](https://github.com/thechangelog/pipely/pull/53)
+  - ✅ Force Fly.io Proxy to serve HTTP/1.1 - [PR #54](https://github.com/thechangelog/pipely/pull/54)
   - Throttle MP3 requests
   - Disable cookies for asset requests (ensure they always get served from cache)
   - Check URL `?args` impact on caching

--- a/fly.io/cdn-2025-12-06/.envrc
+++ b/fly.io/cdn-2025-12-06/.envrc
@@ -2,7 +2,7 @@ source_up
 
 export FLY_APP="cdn-2025-12-06"
 export FLY_APP_PRIMARY_REGION="iad"
-export FLY_APP_REGIONS="sjc,lax,iad,lhr,cdg,ams,fra,sin,nrt"
+export FLY_APP_REGIONS="sjc,lax,dfw,ord,iad,lhr,cdg,ams,fra,sin,nrt"
 export FLY_APP_REGIONS_HOT="sjc,lax,iad,fra,nrt"
 # https://fly.io/docs/about/pricing/#started-fly-machines
 export FLY_APP_DISK_SIZE=200

--- a/fly.io/cdn-2025-12-06/fly.toml
+++ b/fly.io/cdn-2025-12-06/fly.toml
@@ -17,6 +17,11 @@ kill_timeout = 30
 [http_service.http_options]
   idle_timeout = 60
 
+# Force HTTP/1.1 to avoid blocking on body response
+# https://github.com/thechangelog/changelog.com/issues/553
+[http_service.tls_options]
+  alpn = ["http/1.1"]
+
 [http_service.concurrency]
   # This matches Varnish's thread_pools * thread_pool_max - 10%
   hard_limit = 2700

--- a/fly.io/cdn-2025-12-06/machines.txt
+++ b/fly.io/cdn-2025-12-06/machines.txt
@@ -1,21 +1,17 @@
-15 machines have been retrieved from app cdn-2025-12-06.
+11 machines have been retrieved from app cdn-2025-12-06.
 View them in the UI here (​https://fly.io/apps/cdn-2025-12-06/machines/)
 
 [1mcdn-2025-12-06[0m
-ID            	NAME                	STATE  	CHECKS	REGION	ROLE	IMAGE                     	IP ADDRESS                     	VOLUME              	CREATED             	LAST UPDATED        	PROCESS GROUP	SIZE                  
-2873321a446d58	dry-star-4868       	started	1/1   	lhr   	    	thechangelog/pipely:v1.1.0	fdaa:0:4556:a7b:4e3:1f39:500d:2	vol_vx2g2p75z3e8e0wr	2025-12-31T17:42:41Z	2026-01-03T08:05:51Z	app          	performance-1x:2048MB	
-0801900ad35008	muddy-firefly-4617  	started	1/1   	ams   	    	thechangelog/pipely:v1.1.0	fdaa:0:4556:a7b:38:28c1:1420:2 	vol_r1l2lkp7y9nqmoz4	2025-12-31T17:42:41Z	2026-01-03T08:06:12Z	app          	performance-1x:2048MB	
-683727ec1729d8	hidden-shadow-1332  	started	1/1   	cdg   	    	thechangelog/pipely:v1.1.0	fdaa:0:4556:a7b:5b1:ce1d:2609:2	vol_42lelpgj1787589r	2025-12-31T17:42:42Z	2026-01-03T08:06:39Z	app          	performance-1x:2048MB	
-2873241a63e328	still-night-6790    	started	1/1   	fra   	    	thechangelog/pipely:v1.1.0	fdaa:0:4556:a7b:523:91fc:e2f4:2	vol_vz5m52kl92go169v	2025-12-31T17:42:42Z	2026-01-03T08:07:02Z	app          	performance-2x:4096MB	
-080eee0c702098	frosty-darkness-899 	started	1/1   	ewr   	    	thechangelog/pipely:v1.1.0	fdaa:0:4556:a7b:cc:20f:5728:2  	vol_rn8e80w20gzdl00r	2025-12-31T17:42:41Z	2026-01-03T08:07:22Z	app          	performance-2x:4096MB	
-68327e4c47ede8	black-meadow-4415   	started	1/1   	iad   	    	thechangelog/pipely:v1.1.0	fdaa:0:4556:a7b:41a:ad73:8e26:2	vol_vgjp71y9dz73d1pv	2025-12-31T17:40:29Z	2026-01-03T08:07:44Z	app          	performance-2x:4096MB	
-1857001cd725e8	lingering-river-1263	started	1/1   	dfw   	    	thechangelog/pipely:v1.1.0	fdaa:0:4556:a7b:164:4b12:a65c:2	vol_rn8e80wgx87n2d8r	2025-12-31T17:42:44Z	2026-01-03T08:08:30Z	app          	performance-2x:4096MB	
-825de7c7e90358	quiet-wood-777      	started	1/1   	lax   	    	thechangelog/pipely:v1.1.0	fdaa:0:4556:a7b:2b5:cecc:cd19:2	vol_re8k8x2w28p36dor	2025-12-31T17:42:43Z	2026-01-03T08:08:53Z	app          	performance-1x:2048MB	
-d8d31e7a67d498	sparkling-dream-8375	started	1/1   	sjc   	    	thechangelog/pipely:v1.1.0	fdaa:0:4556:a7b:4f3:bc1f:2a90:2	vol_45lnl20o572q10jr	2025-12-31T17:42:43Z	2026-01-03T08:09:15Z	app          	performance-2x:4096MB	
-874dd5c0350338	long-dawn-3414      	started	1/1   	ord   	    	thechangelog/pipely:v1.1.0	fdaa:0:4556:a7b:111:aa74:f5e5:2	vol_vjeqejp7671zw0p4	2025-12-31T17:42:42Z	2026-01-03T08:08:08Z	app          	performance-2x:4096MB	
-48e4d55f311558	wispy-silence-2650  	started	1/1   	sin   	    	thechangelog/pipely:v1.1.0	fdaa:0:4556:a7b:481:665a:954e:2	vol_r77j7xlmnjgqnggr	2025-12-31T17:42:42Z	2026-01-03T08:09:39Z	app          	performance-2x:4096MB	
-08016e4b579178	winter-wind-9541    	started	1/1   	jnb   	    	thechangelog/pipely:v1.1.0	fdaa:0:4556:a7b:2e3:d7a9:11f6:2	vol_vdmjm73ndk0wgo1v	2025-12-31T17:42:41Z	2026-01-03T08:10:02Z	app          	performance-1x:2048MB	
-17817961ade758	wandering-frost-603 	started	1/1   	gru   	    	thechangelog/pipely:v1.1.0	fdaa:0:4556:a7b:5be:6080:7476:2	vol_42lelpg9lqlp760r	2025-12-31T17:42:41Z	2026-01-03T08:10:26Z	app          	performance-1x:2048MB	
-e822074a453e98	weathered-bird-530  	started	1/1   	nrt   	    	thechangelog/pipely:v1.1.0	fdaa:0:4556:a7b:465:b534:b270:2	vol_4o5153k62pjx3m2v	2025-12-31T17:42:43Z	2026-01-03T08:10:50Z	app          	performance-2x:4096MB	
-d8966d5ae40128	damp-lake-5993      	started	1/1   	syd   	    	thechangelog/pipely:v1.1.0	fdaa:0:4556:a7b:4df:864d:6ab2:2	vol_45lnl2055kkoyejr	2025-12-31T17:42:42Z	2026-01-03T08:11:14Z	app          	performance-1x:2048MB	
+ID            	NAME               	STATE  	CHECKS	REGION	ROLE	IMAGE                     	IP ADDRESS                     	VOLUME              	CREATED             	LAST UPDATED        	PROCESS GROUP	SIZE                  
+2873321a446d58	dry-star-4868      	started	1/1   	lhr   	    	thechangelog/pipely:v1.2.0	fdaa:0:4556:a7b:4e3:1f39:500d:2	vol_vx2g2p75z3e8e0wr	2025-12-31T17:42:41Z	2026-02-10T17:04:00Z	app          	performance-1x:2048MB	
+683727ec1729d8	hidden-shadow-1332 	started	1/1   	cdg   	    	thechangelog/pipely:v1.2.0	fdaa:0:4556:a7b:5b1:ce1d:2609:2	vol_42lelpgj1787589r	2025-12-31T17:42:42Z	2026-02-10T17:04:22Z	app          	performance-1x:2048MB	
+0801900ad35008	muddy-firefly-4617 	started	1/1   	ams   	    	thechangelog/pipely:v1.2.0	fdaa:0:4556:a7b:38:28c1:1420:2 	vol_r1l2lkp7y9nqmoz4	2025-12-31T17:42:41Z	2026-02-10T17:04:48Z	app          	performance-1x:2048MB	
+2873241a63e328	still-night-6790   	started	1/1   	fra   	    	thechangelog/pipely:v1.2.0	fdaa:0:4556:a7b:523:91fc:e2f4:2	vol_vz5m52kl92go169v	2025-12-31T17:42:42Z	2026-02-10T17:05:13Z	app          	performance-2x:4096MB	
+68327e4c47ede8	black-meadow-4415  	started	1/1   	iad   	    	thechangelog/pipely:v1.2.0	fdaa:0:4556:a7b:41a:ad73:8e26:2	vol_vgjp71y9dz73d1pv	2025-12-31T17:40:29Z	2026-02-10T17:05:35Z	app          	performance-2x:4096MB	
+3287d797c6e4d8	broken-darkness-3  	started	1/1   	ord   	    	thechangelog/pipely:v1.2.0	fdaa:0:4556:a7b:617:dc92:ea24:2	vol_r1l7pwy6jyk17094	2026-02-10T17:25:11Z	2026-02-10T17:25:43Z	app          	performance-1x:2048MB	
+7843e40f15d958	restless-voice-2378	started	1/1   	dfw   	    	thechangelog/pipely:v1.2.0	fdaa:0:4556:a7b:66:b353:746f:2 	vol_42ljloxwkq1l0z1r	2026-02-10T17:25:11Z	2026-02-10T17:26:05Z	app          	performance-1x:2048MB	
+825de7c7e90358	quiet-wood-777     	started	1/1   	lax   	    	thechangelog/pipely:v1.2.0	fdaa:0:4556:a7b:2b5:cecc:cd19:2	vol_re8k8x2w28p36dor	2025-12-31T17:42:43Z	2026-02-10T17:06:01Z	app          	performance-2x:4096MB	
+2873ed5a776918	rough-glitter-7303 	started	1/1   	sjc   	    	thechangelog/pipely:v1.2.0	fdaa:0:4556:a7b:4f3:ee68:3fe1:2	vol_45lnl20o572q10jr	2026-01-10T08:45:41Z	2026-02-10T17:06:28Z	app          	performance-2x:4096MB	
+48e4d55f311558	wispy-silence-2650 	started	1/1   	sin   	    	thechangelog/pipely:v1.2.0	fdaa:0:4556:a7b:481:665a:954e:2	vol_r77j7xlmnjgqnggr	2025-12-31T17:42:42Z	2026-02-10T17:06:57Z	app          	performance-1x:2048MB	
+e822074a453e98	weathered-bird-530 	started	1/1   	nrt   	    	thechangelog/pipely:v1.2.0	fdaa:0:4556:a7b:465:b534:b270:2	vol_4o5153k62pjx3m2v	2025-12-31T17:42:43Z	2026-02-10T17:07:24Z	app          	performance-2x:4096MB	
 

--- a/fly.io/cdn-2025-12-06/regions.txt
+++ b/fly.io/cdn-2025-12-06/regions.txt
@@ -1,30 +1,30 @@
 NAME                        	CODE	CAPACITY 
                             	
 Africa                      	
-Johannesburg, South Africa  	jnb 	313     	
+Johannesburg, South Africa  	jnb 	289     	
                             	
 Asia Pacific                	
-Mumbai, India               	bom 	157     	
-Singapore, Singapore        	sin 	821     	
-Sydney, Australia           	syd 	483     	
-Tokyo, Japan                	nrt 	-252    	
+Mumbai, India               	bom 	117     	
+Singapore, Singapore        	sin 	28      	
+Sydney, Australia           	syd 	672     	
+Tokyo, Japan                	nrt 	-158    	
                             	
 Europe                      	
-Amsterdam, Netherlands      	ams 	1446    	
-Frankfurt, Germany          	fra 	1272    	
-London, United Kingdom      	lhr 	970     	
-Paris, France               	cdg 	2152    	
-Stockholm, Sweden           	arn 	967     	
+Amsterdam, Netherlands      	ams 	1523    	
+Frankfurt, Germany          	fra 	497     	
+London, United Kingdom      	lhr 	765     	
+Paris, France               	cdg 	2060    	
+Stockholm, Sweden           	arn 	916     	
                             	
 North America               	
-Ashburn, Virginia (US)      	iad 	-1310   	
-Chicago, Illinois (US)      	ord 	20      	
-Dallas, Texas (US)          	dfw 	1067    	
-Los Angeles, California (US)	lax 	698     	
-San Jose, California (US)   	sjc 	533     	
-Secaucus, NJ (US)           	ewr 	-56     	
-Toronto, Canada             	yyz 	787     	
+Ashburn, Virginia (US)      	iad 	-4788   	
+Chicago, Illinois (US)      	ord 	-131    	
+Dallas, Texas (US)          	dfw 	-147    	
+Los Angeles, California (US)	lax 	288     	
+San Jose, California (US)   	sjc 	482     	
+Secaucus, NJ (US)           	ewr 	-196    	
+Toronto, Canada             	yyz 	908     	
                             	
 South America               	
-Sao Paulo, Brazil           	gru 	1707    	
+Sao Paulo, Brazil           	gru 	1643    	
 

--- a/fly.io/cdn-2025-12-06/sizes.txt
+++ b/fly.io/cdn-2025-12-06/sizes.txt
@@ -1,20 +1,25 @@
-Machines platform
-NAME         	CPU CORES	MEMORY
-shared-cpu-1x	1        	256 MB
-shared-cpu-2x	2        	512 MB
-shared-cpu-4x	4        	1 GB
-shared-cpu-8x	8        	2 GB
+[1mMachines platform[0m
+NAME         	CPU CORES	MEMORY 	 
+shared-cpu-1x	1        	256 MB 		
+shared-cpu-2x	2        	512 MB 		
+shared-cpu-4x	4        	1024 MB		
+shared-cpu-6x	6        	1536 MB		
+shared-cpu-8x	8        	2048 MB		
 
-NAME           	CPU CORES	MEMORY
-performance-1x 	1        	2 GB
-performance-2x 	2        	4 GB
-performance-4x 	4        	8 GB
-performance-8x 	8        	16 GB
-performance-16x	16       	32 GB
+NAME           	CPU CORES	MEMORY  	 
+performance-1x 	1        	2048 MB 		
+performance-2x 	2        	4096 MB 		
+performance-4x 	4        	8192 MB 		
+performance-6x 	6        	12288 MB		
+performance-8x 	8        	16384 MB		
+performance-10x	10       	20480 MB		
+performance-12x	12       	24576 MB		
+performance-14x	14       	28672 MB		
+performance-16x	16       	32768 MB		
 
-NAME     	CPU CORES	MEMORY	GPU MODEL
-a10      	8        	32 GB 	a10
-a100-40gb	8        	32 GB 	a100-pcie-40gb
-a100-80gb	8        	32 GB 	a100-sxm4-80gb
-l40s     	8        	32 GB 	l40s
+NAME     	CPU CORES	MEMORY  	GPU MODEL      
+a10      	8        	32768 MB	a10           	
+a100-40gb	8        	32768 MB	a100-pcie-40gb	
+a100-80gb	8        	32768 MB	a100-sxm4-80gb	
+l40s     	8        	32768 MB	l40s          	
 

--- a/justfile
+++ b/justfile
@@ -84,6 +84,8 @@ test-acceptance-production *ARGS:
 [parallel]
 check-all http="1.1": (check "sjc" http) \
                       (check "lax" http) \
+                      (check "dfw" http) \
+                      (check "ord" http) \
                       (check "iad" http) \
                       (check "lhr" http) \
                       (check "cdg" http) \


### PR DESCRIPTION
Otherwise the body stalls. This has been a long-running issue...

Also:
- bump just to 1.46.0
- run checks hourly (to ensure that the fix holds)
- add back DFW & ORD regions to cover the US better

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Infrastructure Updates**
  * Added Dallas (dfw) and Chicago (ord) regions; machine images bumped to v1.2.0 and machine count reduced
  * Standardized memory specs across all tiers to MB; region capacities updated

* **Configuration**
  * Enforced HTTP/1.1 via TLS ALPN
  * Monitoring workflow now runs hourly

* **Testing**
  * Broadened cache TTL test expectations; added dfw/ord checks to acceptance run

* **Documentation**
  * Roadmap updated with HTTP/1.1 proxy item

* **Chores**
  * Bumped setup-just to v1.46.0
<!-- end of auto-generated comment: release notes by coderabbit.ai -->