### PR TITLE
Always cache asset responses

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,176 @@
+# AGENTS.md
+
+Orientation for coding agents working on **Pipely** — a single-purpose,
+single-tenant CDN for changelog.com: Varnish Cache 7.7.3 running on Fly.io.
+Keep this file updated as the codebase evolves.
+
+## Big picture
+
+```text
+client
+└── DNS: DNSimple (A records → Fly dedicated IPv4 137.66.16.250)
+    └── Fly.io proxy (app cdn-2025-12-06, 11 regions, 1 machine per region)
+        └── container — processes supervised by overmind
+            │           (Procfile generated in dagger/main.go:250)
+            ├── varnishd :9000 — HTTP/2, malloc storage + optional file storage
+            │   ├── app     → tls-exterminator :5000 → changelog-2025-05-05.fly.dev (Phoenix)
+            │   ├── assets  → tls-exterminator :5010 → changelog.place (Cloudflare)
+            │   ├── feeds   → tls-exterminator :5020 → feeds.changelog.place (Cloudflare)
+            │   └── nightly → tls-exterminator :5030 → changelog-nightly-2023-10-10.fly.dev
+            └── logs — varnish-json-response.bash (varnishncsa → JSON)
+                       piped into Vector via a bash coproc
+```
+
+tls-exterminator exists because Varnish speaks plain HTTP: each backend
+points at `localhost:<port>`, where the proxy adds TLS + SNI to the real
+origin. Backend selection per request:
+
+| Backend | Selected by                          |
+|---------|--------------------------------------|
+| app     | default — set unconditionally first  |
+| assets  | `Host: cdn.changelog.com`            |
+| feeds   | URL rules in `feeds-backend.vcl`     |
+| nightly | `Host: nightly.changelog.com`        |
+
+Backends are libvmod-dynamic directors (declared in
+`varnish/vcl/default.vcl` `vcl_init`, ttl=10s DNS, health probes on
+`/health`). The static default backend is disabled (`backend default none;`).
+
+## VCL mechanics you must understand before editing
+
+- `varnish/vcl/default.vcl` is the entrypoint; everything else is an
+  `include`. Varnish **concatenates same-named subs in include order** —
+  `app-backend.vcl` is included first, so its `vcl_recv` runs first and sets
+  the app backend as the default; later includes (assets, feeds, nightly,
+  redirects) override `req.backend_hint` when their conditions match.
+- **No `vcl_recv` sub ever `return`s**, so the *builtin* `vcl_recv` runs
+  last: any request with a `Cookie` or `Authorization` header is
+  `pass`ed (never cached, `cache_status=pass`). Feeds & assets routes
+  `unset` both headers (responses never vary on credentials there) so they
+  always cache; app & nightly requests keep credentials and bypass the
+  cache. Guarded by `test/vtc/credentials.vtc`.
+- Feed URLs are **normalized** to the canonical `/<feed>.xml` form before
+  hashing & fetching (query string dropped): `/feed` & `/rss` → `/feed.xml`,
+  `/<pod>/feed` → `/<pod>.xml`, `/feeds/<x>` → `/<x>.xml`. Direct requests
+  for the canonical form are routed to the feeds backend via an allowlist.
+  Exception: the ++ feed is private, reachable only via its tokenized URL —
+  `/plusplus.xml` is deliberately absent from the allowlist, the `/feeds/*`
+  wildcard excludes it, and the rewrite to `/plusplus.xml` happens in
+  `vcl_backend_fetch` so the token stays in the cache key (a token-less
+  request can never hit the cached private feed). Guarded by
+  `test/vtc/plusplus.vtc`.
+- Per-backend cache policy lives in each file's `vcl_backend_response`,
+  guarded by `bereq.http.x-backend-<name>` markers:
+  - app & nightly: memory, ttl 1m / grace 1d / keep 7d
+  - feeds: memory, ttl 12h / grace 1d / keep 7d
+  - assets: ttl 1d / grace 2d / keep 7d; `.mp3` → `storage.disk`
+    (file cache on the Fly volume) + `do_stream`; everything else memory
+  - 5xx: uncacheable; bg-fetch 5xx → `abandon` so stale objects survive
+    (`disable-caching-for-5xx.vcl`)
+- `BERESP_TTL` / `BERESP_GRACE` / `BERESP_KEEP` env vars override all of the
+  above (dev/test only — `just local-debug` sets ttl=5s).
+- Other routing: `www.*` → 301 apex; `x-forwarded-proto: http` → 301 https;
+  websocket upgrades → `pipe`; `PURGE` requires `Purge-Token` header matching
+  `PURGE_TOKEN` env; `/health` → synth 204 (Fly health check);
+  `/{app,assets,feeds,nightly}_health` → `pass` to that origin's `/health`;
+  `/practicalai*` → 301 off-site; old news MP3 paths → 308 to
+  cdn.changelog.com (`news-mp3.vcl`).
+- `varnish/changelog.com.vcl` is the **legacy Fastly VCL, reference only**
+  (source of ported redirects) — never deployed.
+- Keep VCL lean: `just how-many-lines` counts effective lines; small & simple
+  is an explicit project goal.
+
+## Observability
+
+- `vcl_deliver`/`vcl_synth` build the `cache-status` response header:
+  `region=X; origin=Y; ttl=…; grace=…; keep=…; storage=…; hit|miss|bypass|synth; hits=N`.
+  Acceptance tests assert on its parts — keep format stable.
+- Every `std.log("key:value")` in VCL becomes a JSON field via the
+  `varnishncsa` format string in `varnish/varnish-json-response.bash`
+  (add new fields in both places).
+- Vector pipeline (`vector/changelog.com/`): stdin JSON → GeoIP enrichment
+  (MaxMind mmdb, only when built with `--max-mind-auth`) → Honeycomb sink +
+  S3 sinks (JSON for feeds, CSV per podcast for MP3 stats).
+- Honeycomb dataset: production `pipedream` (set via `just fly secrets`),
+  local `pipedream-local` (.envrc); the dagger default `pipely` is unused in
+  practice. S3 buckets `changelog-logs-*`, local suffix `-pipedream-local`.
+- `x-request-id` echoes Fly's `fly-request-id`.
+- `app_generation` & `region` (logged, and `region` is in `cache-status`)
+  are read once in `vcl_init` from `FLY_APP_NAME` / `FLY_REGION`. Fly exposes
+  `FLY_APP_NAME`, **not** `FLY_APP` — reading the latter logs the `NOW`
+  fallback on every machine. Local/test fall back to `NOW` / `LOCAL`.
+
+## Build, test, run (everything is `just` + Dagger)
+
+Host prerequisites: Docker + just ≥1.35 only. Recipes self-install pinned
+dagger/hurl/flyctl/op into `~/.local/bin` (versions pinned in `just/*.just`;
+container tool versions pinned in `dagger/main.go` consts).
+
+**Always go through the `just` recipes** — never invoke `docker`, `dagger`,
+`varnishtest`, `hurl` or `flyctl` directly. The recipes pin versions and
+encode the supported workflow. Only fall back to a raw command when no
+recipe covers the need, and call that out explicitly when you do.
+
+> Sandbox gotcha: Dagger resolves the module context via git and fails hard
+> (`git config error: ... exit status 128`) if `.git` is present but broken
+> — e.g. a worktree checkout whose parent repo isn't mounted (`.git` is a
+> `gitdir:` pointer file, not a directory). Symptom: `just test`/`test-vtc`
+> die at "go SDK: load runtime" before any test runs. Fix: make git valid,
+> or move the dead `.git` pointer aside so Dagger treats the dir as plain
+> files.
+
+- `just test` — VTC + local acceptance (what CI runs on every PR)
+- `just test-vtc` — `varnishtest` against `test/vtc/*.vtc` inside the
+  container image
+- `just test-acceptance-local` — hurl files in `test/acceptance/` against a
+  containerized instance (service-bound as `pipely:9000`); HTML report
+  exported to `tmp/`
+- `just local-run` / `local-debug` — run/shell the container locally on :9000
+  (the container has its own justfile: `container/justfile` — varnish tools,
+  benchmarks, etc.)
+- `just check-all` — periodic per-region production checks
+  (`test/acceptance/periodic/region.hurl`, uses `Fly-Force-Region` header);
+  also runs daily via `.github/workflows/check_all.yml`
+- `[team]` recipes need 1Password: `just envrc-secrets` renders
+  `.envrc.secrets` from `envrc.secrets.op` (direnv loads it)
+
+### Writing tests
+
+- VTC: each file mocks origins with `server s1 {…}`, sets backend env vars
+  via `setenv`, re-declares the dynamic director **without a probe**, and
+  includes only the VCL files under test plus
+  `test/disable-caching-for-testing.vcl` and `disable-default-backend.vcl`.
+  Mock servers consume requests **in order** — every client request needs a
+  matching `rxreq/txresp` block.
+- Routing changes need both: a VTC case (unit) and a hurl case (acceptance).
+  Note `test/acceptance/feeds.hurl` asserts against production-shaped
+  responses (`cf-ray` from Cloudflare origins, `age`, `content-type`).
+
+## CI / deployment
+
+- `.github/workflows/ship_it.yml`: PRs/pushes run `just test` on
+  Namespace.so runners with a GitHub-runner fallback (`_namespace.yml` /
+  `_github.yml` are identical in outcome). Pushing a `v*` tag additionally
+  runs `just publish <tag>` (ghcr.io/thechangelog/pipely), `just deploy
+  <tag>` in `fly.io/cdn-2025-12-06/`, then `just test-acceptance-production`.
+- Release flow: `just tag <tag> <sha> <discussion-id>` (signed tag linking a
+  GitHub discussion), push tag, CI does the rest. README tracks the roadmap
+  per release — update it.
+- Fly app `cdn-2025-12-06`, dedicated IPv4 `137.66.16.250` (acceptance tests
+  `--resolve` against it). 11 regions; HOT regions (sjc,lax,iad,fra,nrt) are
+  performance-2x/4GB, COLD are performance-1x/2GB; every machine has a 200GB
+  `varnish_file_cache` volume. `VARNISH_SIZE` = 70% of RAM,
+  `VARNISH_FILE_SIZE` = 90% of disk (set by `just deploy`/`scale`, see
+  `just/fly.just`). Region/sizing config: `fly.io/cdn-2025-12-06/.envrc`.
+- Fly proxy forces HTTP/1.1 via ALPN (`fly.toml`) to avoid response-body
+  blocking (changelog.com issue #553); concurrency hard_limit 2700 ≈
+  thread_pools(2) × thread_pool_max(1500) − 10%.
+- New-instance rollout checklist: `fly.io/README.md`.
+
+## Conventions
+
+- Commit messages: descriptive, human-first (https://cbea.ms/git-commit/).
+- Discussion happens in Zulip (#pipely) and Changelog "Kaizen" episodes;
+  releases reference GitHub discussions.
+- Docs are lean on purpose: `docs/local_dev.md` for local workflow,
+  `fly.io/README.md` for rollouts, README for roadmap/history.

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ You are welcome to fork this and build your own - OSS FTW 💚
 - Tag & ship `v1.3`
   - ✅ Run periodic HTTP/1.1 checks (on top of HTTP/2) - [PR #53](https://github.com/thechangelog/pipely/pull/53)
   - ✅ Force Fly.io Proxy to serve HTTP/1.1 - [PR #54](https://github.com/thechangelog/pipely/pull/54)
+  - ✅ Always cache asset responses - [PR #56](https://github.com/thechangelog/pipely/pull/56)
   - Throttle MP3 requests
-  - Disable cookies for asset requests (ensure they always get served from cache)
   - Check URL `?args` impact on caching
   - Replace `coproc` with `svlogd` (a.k.a. overmind with runit)
   - TBD...

--- a/just/dagger.just
+++ b/just/dagger.just
@@ -2,8 +2,17 @@
 
 [private]
 DAGGER_VERSION := "0.19.8"
+
+# Use ghcr.io to work around:
+#
+# Error response from daemon: Get "https://registry.dagger.io/v2/": context
+# deadline exceeded (Client.Timeout exceeded while awaiting headers)
+[private]
+export _EXPERIMENTAL_DAGGER_RUNNER_HOST := "docker-image://ghcr.io/dagger/engine:v" + DAGGER_VERSION
+
 [private]
 DAGGER_DIR := BIN_PATH / "pipely-dagger-" + DAGGER_VERSION
+
 [private]
 DAGGER := env("DAGGER_BIN", DAGGER_DIR / "dagger")
 

--- a/test/acceptance/assets.hurl
+++ b/test/acceptance/assets.hurl
@@ -49,6 +49,17 @@ header "cf-ray" exists # served by Cloudflare
 header "via" matches /[vV]arnish/ # served via Varnish
 header "age" exists # cache age works
 
+# Get the static asset with credentials: must not bypass the cache
+GET {{proto}}://{{host}}/static/images/podcasts/podcast-original-f16d0363067166f241d080ee2e2d4a28.png
+Host: {{assets_host}}
+Cookie: hurl=true
+Authorization: Bearer hurl
+HTTP 200 # expect OK response
+[Asserts]
+header "via" matches /[vV]arnish/ # served via Varnish
+header "cache-status" contains "hit" # served from cache despite credentials
+header "cache-status" not contains "bypass" # not passed to the origin
+
 POST {{proto}}://{{host}}/static/images/podcasts/podcast-original-f16d0363067166f241d080ee2e2d4a28.png
 Host: {{assets_host}}
 HTTP 405 # expect method not allowed

--- a/test/acceptance/feeds.hurl
+++ b/test/acceptance/feeds.hurl
@@ -51,6 +51,17 @@ header "cache-status" contains "storage.memory" # cached in memory
 header "cache-status" not contains "stale" # not stale
 header "content-type" contains "application/xml" # content type is XML
 
+# Get the changelog feed with credentials: must not bypass the cache
+GET {{proto}}://{{host}}/podcast/feed?hurl=true
+Cookie: hurl=true
+Authorization: Bearer hurl
+HTTP 200 # expect OK response
+[Asserts]
+header "via" matches /[vV]arnish/ # served via Varnish
+header "cache-status" contains "hit" # served from cache despite credentials
+header "cache-status" not contains "bypass" # not passed to the origin
+header "content-type" contains "application/xml" # content type is XML
+
 GET {{proto}}://{{host}}/gotime/feed
 HTTP 200 # expect OK response
 [Asserts]
@@ -172,3 +183,33 @@ header "cf-ray" exists # served by Cloudflare
 header "via" matches /[vV]arnish/ # served via Varnish
 header "age" exists # cache age works
 header "content-type" contains "application/xml" # content type is XML
+
+# Direct requests for the canonical feed URLs (old bookmarks & crawlers)
+GET {{proto}}://{{host}}/feed.xml
+HTTP 200 # expect OK response
+[Asserts]
+header "cf-ray" exists # served by Cloudflare
+header "via" matches /[vV]arnish/ # served via Varnish
+header "age" exists # cache age works
+header "cache-status" contains "origin=feeds" # served by feeds backend, not app
+header "content-type" contains "application/xml" # content type is XML
+
+GET {{proto}}://{{host}}/podcast.xml
+HTTP 200 # expect OK response
+[Asserts]
+header "cf-ray" exists # served by Cloudflare
+header "via" matches /[vV]arnish/ # served via Varnish
+header "age" exists # cache age works
+header "cache-status" contains "origin=feeds" # served by feeds backend, not app
+header "content-type" contains "application/xml" # content type is XML
+
+# The private ++ feed must NOT be reachable without its token
+GET {{proto}}://{{host}}/plusplus.xml
+HTTP 404 # expect Not Found
+[Asserts]
+header "cache-status" contains "origin=app" # not routed to the feeds backend
+
+GET {{proto}}://{{host}}/feeds/plusplus
+HTTP 404 # expect Not Found
+[Asserts]
+header "cache-status" contains "origin=app" # not routed to the feeds backend

--- a/test/vtc/credentials.vtc
+++ b/test/vtc/credentials.vtc
@@ -1,0 +1,54 @@
+varnishtest "Cookies & Authorization are stripped from FEEDS requests"
+
+# Without the credential strip, the builtin vcl_recv passes every request
+# carrying a Cookie or Authorization header, so nothing would be cached.
+# The mock server accepts a SINGLE request: the repeat client below only
+# succeeds when served from the cache.
+
+# Feeds mock server
+server s1 {
+  rxreq
+  expect req.url == "/podcast.xml"
+  expect req.http.x-forwarded-host == "feeds.local"
+  expect req.http.cookie == <undef>
+  expect req.http.authorization == <undef>
+  txresp -status 200 -body "podcast.xml"
+} -start
+
+setenv FEEDS_HOST "feeds.local"
+setenv BACKEND_FEEDS_FQDN "feeds.origin.local"
+setenv BACKEND_FEEDS_HOST "${s1_addr}"
+setenv BACKEND_FEEDS_PORT "${s1_port}"
+
+# Caching is intentionally ENABLED: these tests assert on cacheability
+varnish v1 -arg "-s memory=malloc,10M" -vcl {
+  vcl 4.1;
+  import dynamic;
+  import std;
+
+  # Use a feeds backend with no probe when testing
+  sub vcl_init {
+    new feeds = dynamic.director(
+      host_header = std.getenv("BACKEND_FEEDS_FQDN"),
+    );
+  }
+
+  include "feeds-backend.vcl";
+  include "disable-default-backend.vcl";
+} -start
+
+# A feed request with credentials is fetched from the backend without them...
+client c1 {
+  txreq -url "/podcast/feed" -hdr "Cookie: session=abc" -hdr "Authorization: Bearer abc"
+  rxresp
+  expect resp.status == 200
+  expect resp.body == "podcast.xml"
+} -run
+
+# ...and is served from the cache on repeat
+client c2 {
+  txreq -url "/podcast/feed" -hdr "Cookie: session=abc" -hdr "Authorization: Bearer abc"
+  rxresp
+  expect resp.status == 200
+  expect resp.body == "podcast.xml"
+} -run

--- a/test/vtc/credentials.vtc
+++ b/test/vtc/credentials.vtc
@@ -1,9 +1,9 @@
-varnishtest "Cookies & Authorization are stripped from FEEDS requests"
+varnishtest "Cookies & Authorization are stripped from FEEDS & ASSETS requests"
 
 # Without the credential strip, the builtin vcl_recv passes every request
 # carrying a Cookie or Authorization header, so nothing would be cached.
-# The mock server accepts a SINGLE request: the repeat client below only
-# succeeds when served from the cache.
+# Each mock server accepts a SINGLE request: the repeat clients below only
+# succeed when served from the cache.
 
 # Feeds mock server
 server s1 {
@@ -20,19 +20,40 @@ setenv BACKEND_FEEDS_FQDN "feeds.origin.local"
 setenv BACKEND_FEEDS_HOST "${s1_addr}"
 setenv BACKEND_FEEDS_PORT "${s1_port}"
 
+# Assets mock server
+server s2 {
+  rxreq
+  expect req.url == "/static/logo.png"
+  expect req.http.x-forwarded-host == "assets.local"
+  expect req.http.cookie == <undef>
+  expect req.http.authorization == <undef>
+  txresp -status 200 -body "logo.png"
+} -start
+
+setenv ASSETS_HOST "assets.local"
+setenv BACKEND_ASSETS_FQDN "assets.origin.local"
+setenv BACKEND_ASSETS_HOST "${s2_addr}"
+setenv BACKEND_ASSETS_PORT "${s2_port}"
+
 # Caching is intentionally ENABLED: these tests assert on cacheability
-varnish v1 -arg "-s memory=malloc,10M" -vcl {
+varnish v1 -arg "-s memory=malloc,10M" \
+           -arg "-s disk=file,${tmpdir}/file.bin,10M" -vcl {
   vcl 4.1;
   import dynamic;
   import std;
 
-  # Use a feeds backend with no probe when testing
+  # Use assets & feeds backends with no probe when testing
   sub vcl_init {
+    new assets = dynamic.director(
+      host_header = std.getenv("BACKEND_ASSETS_FQDN"),
+    );
+
     new feeds = dynamic.director(
       host_header = std.getenv("BACKEND_FEEDS_FQDN"),
     );
   }
 
+  include "assets-backend.vcl";
   include "feeds-backend.vcl";
   include "disable-default-backend.vcl";
 } -start
@@ -51,4 +72,22 @@ client c2 {
   rxresp
   expect resp.status == 200
   expect resp.body == "podcast.xml"
+} -run
+
+# An assets request with credentials is fetched from the backend without them...
+client c3 {
+  txreq -url "/static/logo.png" -hdr "Host: assets.local" \
+        -hdr "Cookie: session=abc" -hdr "Authorization: Bearer abc"
+  rxresp
+  expect resp.status == 200
+  expect resp.body == "logo.png"
+} -run
+
+# ...and is served from the cache on repeat
+client c4 {
+  txreq -url "/static/logo.png" -hdr "Host: assets.local" \
+        -hdr "Cookie: session=abc" -hdr "Authorization: Bearer abc"
+  rxresp
+  expect resp.status == 200
+  expect resp.body == "logo.png"
 } -run

--- a/test/vtc/default.vtc
+++ b/test/vtc/default.vtc
@@ -65,7 +65,7 @@ setenv BERESP_GRACE "1m"
 setenv BERESP_KEEP "1h"
 
 setenv FLY_REGION "lgz"
-setenv FLY_APP "local-2026-01-10"
+setenv FLY_APP_NAME "local-2026-01-10"
 
 # Start Varnish with a VCL close to our final one
 varnish v1 -arg "-s memory=malloc,10M" \
@@ -82,8 +82,8 @@ varnish v1 -arg "-s memory=malloc,10M" \
 
   # Use an app backend with no probe when testing
   sub vcl_init {
-    if (std.getenv("FLY_APP") && std.getenv("FLY_APP") != "") {
-        var.global_set("app_generation", std.getenv("FLY_APP"));
+    if (std.getenv("FLY_APP_NAME") && std.getenv("FLY_APP_NAME") != "") {
+        var.global_set("app_generation", std.getenv("FLY_APP_NAME"));
     } else {
         var.global_set("app_generation", "NOW");
     }

--- a/test/vtc/feeds-backend.vtc
+++ b/test/vtc/feeds-backend.vtc
@@ -326,6 +326,24 @@ server s1 {
   expect req.url == "/0284CC5C777C51D158BBECCBBB56422A.xml"
   expect req.http.x-forwarded-host == "feeds.local"
   txresp -status 200 -body "0284CC5C777C51D158BBECCBBB56422A.xml"
+
+  # Test for /feed.xml (direct request for the canonical form)
+  rxreq
+  expect req.url == "/feed.xml"
+  expect req.http.x-forwarded-host == "feeds.local"
+  txresp -status 200 -body "feed.xml"
+
+  # Test for /feed.xml?arg=first&arg=second (query string is dropped)
+  rxreq
+  expect req.url == "/feed.xml"
+  expect req.http.x-forwarded-host == "feeds.local"
+  txresp -status 200 -body "feed.xml"
+
+  # Test for /podcast.xml (direct request for the canonical form)
+  rxreq
+  expect req.url == "/podcast.xml"
+  expect req.http.x-forwarded-host == "feeds.local"
+  txresp -status 200 -body "podcast.xml"
 } -start
 
 setenv FEEDS_HOST "feeds.local"
@@ -782,4 +800,50 @@ client c54 {
   rxresp
   expect resp.status == 200
   expect resp.body == "0284CC5C777C51D158BBECCBBB56422A.xml"
+} -run
+
+# /feed.xml (direct request for the canonical form) should go to feeds backend
+client c55 {
+  txreq -url "/feed.xml"
+  rxresp
+  expect resp.status == 200
+  expect resp.body == "feed.xml"
+} -run
+
+# /feed.xml?arg=first&arg=second should go to feeds backend, query dropped
+client c56 {
+  txreq -url "/feed.xml?arg=first&arg=second"
+  rxresp
+  expect resp.status == 200
+  expect resp.body == "feed.xml"
+} -run
+
+# /podcast.xml (direct request for the canonical form) should go to feeds backend
+client c57 {
+  txreq -url "/podcast.xml"
+  rxresp
+  expect resp.status == 200
+  expect resp.body == "podcast.xml"
+} -run
+
+# /plusplus.xml must NOT be routed to the feeds backend (private feed, only
+# reachable via its tokenized URL); no backend matches, so Varnish returns 503
+client c58 {
+  txreq -url "/plusplus.xml"
+  rxresp
+  expect resp.status == 503
+} -run
+
+# An .xml URL outside the allowlist must NOT be routed to the feeds backend
+client c59 {
+  txreq -url "/not-a-feed.xml"
+  rxresp
+  expect resp.status == 503
+} -run
+
+# A client-injected x-backend-feeds header must NOT influence routing
+client c60 {
+  txreq -url "/not-a-feed" -hdr "x-backend-feeds: true"
+  rxresp
+  expect resp.status == 503
 } -run

--- a/test/vtc/plusplus.vtc
+++ b/test/vtc/plusplus.vtc
@@ -1,0 +1,66 @@
+varnishtest "Private ++ feed is only reachable via its tokenized URL"
+
+# Feeds mock server: accepts a SINGLE request, so any test request below
+# that is not served from the cache (or not routed at all) fails this test
+server s1 {
+  # Test for /plusplus/xae9heiphohtupha1Ahha3aexoo0oo4W/feed
+  rxreq
+  expect req.url == "/plusplus.xml"
+  expect req.http.x-forwarded-host == "feeds.local"
+  txresp -status 200 -body "plusplus.xml"
+} -start
+
+setenv FEEDS_HOST "feeds.local"
+setenv BACKEND_FEEDS_FQDN "feeds.origin.local"
+setenv BACKEND_FEEDS_HOST "${s1_addr}"
+setenv BACKEND_FEEDS_PORT "${s1_port}"
+
+# Caching is intentionally ENABLED: these tests assert on cache keys
+varnish v1 -arg "-s memory=malloc,10M" -vcl {
+  vcl 4.1;
+  import dynamic;
+  import std;
+
+  # Use a feeds backend with no probe when testing
+  sub vcl_init {
+    new feeds = dynamic.director(
+      host_header = std.getenv("BACKEND_FEEDS_FQDN"),
+    );
+  }
+
+  include "feeds-backend.vcl";
+  include "disable-default-backend.vcl";
+} -start
+
+# The tokenized URL is served by the feeds backend & cached
+client c1 {
+  txreq -url "/plusplus/xae9heiphohtupha1Ahha3aexoo0oo4W/feed"
+  rxresp
+  expect resp.status == 200
+  expect resp.body == "plusplus.xml"
+} -run
+
+# A direct /plusplus.xml request must NOT hit the cached private feed: the
+# token is part of the cache key & no feeds rule matches, so with no backend
+# configured Varnish returns 503
+client c2 {
+  txreq -url "/plusplus.xml"
+  rxresp
+  expect resp.status == 503
+} -run
+
+# /feeds/plusplus must NOT bypass the token via the /feeds/* wildcard
+client c3 {
+  txreq -url "/feeds/plusplus"
+  rxresp
+  expect resp.status == 503
+} -run
+
+# Tokenized URL variants are normalized to a single cache key:
+# this is a cache hit, the mock server only serves a single request
+client c4 {
+  txreq -url "/plusplus/xae9heiphohtupha1Ahha3aexoo0oo4W/feed/"
+  rxresp
+  expect resp.status == 200
+  expect resp.body == "plusplus.xml"
+} -run

--- a/varnish/vcl/assets-backend.vcl
+++ b/varnish/vcl/assets-backend.vcl
@@ -11,6 +11,12 @@ sub vcl_recv {
     set req.http.x-backend-assets = true;
     set req.http.x-forwarded-host = std.getenv("ASSETS_HOST");
 
+    # Assets are public static files: credentials never affect the response.
+    # Drop them so that the builtin vcl_recv does not pass these requests
+    # (they would never be served from the cache otherwise).
+    unset req.http.cookie;
+    unset req.http.authorization;
+
     # Reject non-GET/HEAD/OPTIONS/PURGE requests
     if (req.method !~ "GET|HEAD|OPTIONS|PURGE") {
       return(synth(405, "Method Not Allowed"));

--- a/varnish/vcl/default.vcl
+++ b/varnish/vcl/default.vcl
@@ -10,8 +10,8 @@ import var;
 # We are declaring the dynamic directors here so that when testing & importing the backends
 # we can define dynamic directors WITHOUT health probes
 sub vcl_init {
-  if (std.getenv("FLY_APP") && std.getenv("FLY_APP") != "") {
-      var.global_set("app_generation", std.getenv("FLY_APP"));
+  if (std.getenv("FLY_APP_NAME") && std.getenv("FLY_APP_NAME") != "") {
+      var.global_set("app_generation", std.getenv("FLY_APP_NAME"));
   } else {
       var.global_set("app_generation", "NOW");
   }

--- a/varnish/vcl/feeds-backend.vcl
+++ b/varnish/vcl/feeds-backend.vcl
@@ -1,6 +1,10 @@
 import std;
 
 sub vcl_recv {
+  # This header selects the FEEDS backend & cache policy below.
+  # Unset it on every client request to prevent header injection.
+  unset req.http.x-backend-feeds;
+
   if (req.url == "/feeds_health") {
     set req.backend_hint = feeds.backend(std.getenv("BACKEND_FEEDS_HOST"), std.getenv("BACKEND_FEEDS_PORT"));
     set req.http.x-backend-fqdn = std.getenv("BACKEND_FEEDS_FQDN");
@@ -11,120 +15,66 @@ sub vcl_recv {
   }
 
   ### Feed requests
-  # Ordered by number of requests in April 2025 (most popular at the top)
+  #
+  # Normalize all feed URLs to the canonical /<feed>.xml form, the only form
+  # served by the feeds backend. The query string is always dropped: feeds are
+  # static files & this keeps a single cache object per feed.
+  #
+  # Feed allowlist based on requests in April 2025:
   # https://ui.honeycomb.io/changelog/datasets/fastly/board-query/xCqdG5ysitw/result/da96aC9mAQf
   #
   # TODO: Upload feed.json too?
   #
   # FWIW 🤦 https://github.com/varnishcache/varnish-cache/issues/2355
-  if (req.url ~ "^/podcast/feed/?(\?.*)?$") {
-    set req.backend_hint = feeds.backend(std.getenv("BACKEND_FEEDS_HOST"), std.getenv("BACKEND_FEEDS_PORT"));
-    set req.http.x-backend-fqdn = std.getenv("BACKEND_FEEDS_FQDN");
+
+  # Podcast feeds, e.g. /podcast/feed → /podcast.xml
+  if (req.url ~ "^/(podcast|gotime|master|jsparty|shipit|news|brainscience|founderstalk|interviews|friends|rfc|spotlight|afk|posts)/feed/?(\?.*)?$") {
+    set req.url = regsub(req.url, "^/([a-z]+)/feed/?(\?.*)?$", "/\1.xml");
     set req.http.x-backend-feeds = true;
-    set req.http.x-forwarded-host = std.getenv("FEEDS_HOST");
-    set req.url = "/podcast.xml";
-  } else if (req.url ~ "^/gotime/feed/?(\?.*)?$") {
-    set req.backend_hint = feeds.backend(std.getenv("BACKEND_FEEDS_HOST"), std.getenv("BACKEND_FEEDS_PORT"));
-    set req.http.x-backend-fqdn = std.getenv("BACKEND_FEEDS_FQDN");
-    set req.http.x-backend-feeds = true;
-    set req.http.x-forwarded-host = std.getenv("FEEDS_HOST");
-    set req.url = "/gotime.xml";
-  } else if (req.url ~ "^/master/feed/?(\?.*)?$") {
-    set req.backend_hint = feeds.backend(std.getenv("BACKEND_FEEDS_HOST"), std.getenv("BACKEND_FEEDS_PORT"));
-    set req.http.x-backend-fqdn = std.getenv("BACKEND_FEEDS_FQDN");
-    set req.http.x-backend-feeds = true;
-    set req.http.x-forwarded-host = std.getenv("FEEDS_HOST");
-    set req.url = "/master.xml";
-  } else if (req.url ~ "^/feed/?(\?.*)?$") {
-    set req.backend_hint = feeds.backend(std.getenv("BACKEND_FEEDS_HOST"), std.getenv("BACKEND_FEEDS_PORT"));
-    set req.http.x-backend-fqdn = std.getenv("BACKEND_FEEDS_FQDN");
-    set req.http.x-backend-feeds = true;
-    set req.http.x-forwarded-host = std.getenv("FEEDS_HOST");
+  # Site-wide feed aliases
+  } else if (req.url ~ "^/(feed|rss)/?(\?.*)?$") {
     set req.url = "/feed.xml";
-  } else if (req.url ~ "^/jsparty/feed/?(\?.*)?$") {
-    set req.backend_hint = feeds.backend(std.getenv("BACKEND_FEEDS_HOST"), std.getenv("BACKEND_FEEDS_PORT"));
-    set req.http.x-backend-fqdn = std.getenv("BACKEND_FEEDS_FQDN");
     set req.http.x-backend-feeds = true;
-    set req.http.x-forwarded-host = std.getenv("FEEDS_HOST");
-    set req.url = "/jsparty.xml";
-  } else if (req.url ~ "^/shipit/feed/?(\?.*)?$") {
-    set req.backend_hint = feeds.backend(std.getenv("BACKEND_FEEDS_HOST"), std.getenv("BACKEND_FEEDS_PORT"));
-    set req.http.x-backend-fqdn = std.getenv("BACKEND_FEEDS_FQDN");
-    set req.http.x-backend-feeds = true;
-    set req.http.x-forwarded-host = std.getenv("FEEDS_HOST");
-    set req.url = "/shipit.xml";
-  } else if (req.url ~ "^/news/feed/?(\?.*)?$") {
-    set req.backend_hint = feeds.backend(std.getenv("BACKEND_FEEDS_HOST"), std.getenv("BACKEND_FEEDS_PORT"));
-    set req.http.x-backend-fqdn = std.getenv("BACKEND_FEEDS_FQDN");
-    set req.http.x-backend-feeds = true;
-    set req.http.x-forwarded-host = std.getenv("FEEDS_HOST");
-    set req.url = "/news.xml";
-  } else if (req.url ~ "^/brainscience/feed/?(\?.*)?$") {
-    set req.backend_hint = feeds.backend(std.getenv("BACKEND_FEEDS_HOST"), std.getenv("BACKEND_FEEDS_PORT"));
-    set req.http.x-backend-fqdn = std.getenv("BACKEND_FEEDS_FQDN");
-    set req.http.x-backend-feeds = true;
-    set req.http.x-forwarded-host = std.getenv("FEEDS_HOST");
-    set req.url = "/brainscience.xml";
-  } else if (req.url ~ "^/founderstalk/feed/?(\?.*)?$") {
-    set req.backend_hint = feeds.backend(std.getenv("BACKEND_FEEDS_HOST"), std.getenv("BACKEND_FEEDS_PORT"));
-    set req.http.x-backend-fqdn = std.getenv("BACKEND_FEEDS_FQDN");
-    set req.http.x-backend-feeds = true;
-    set req.http.x-forwarded-host = std.getenv("FEEDS_HOST");
-    set req.url = "/founderstalk.xml";
-  } else if (req.url ~ "^/interviews/feed/?(\?.*)?$") {
-    set req.backend_hint = feeds.backend(std.getenv("BACKEND_FEEDS_HOST"), std.getenv("BACKEND_FEEDS_PORT"));
-    set req.http.x-backend-fqdn = std.getenv("BACKEND_FEEDS_FQDN");
-    set req.http.x-backend-feeds = true;
-    set req.http.x-forwarded-host = std.getenv("FEEDS_HOST");
-    set req.url = "/interviews.xml";
-  } else if (req.url ~ "^/friends/feed/?(\?.*)?$") {
-    set req.backend_hint = feeds.backend(std.getenv("BACKEND_FEEDS_HOST"), std.getenv("BACKEND_FEEDS_PORT"));
-    set req.http.x-backend-fqdn = std.getenv("BACKEND_FEEDS_FQDN");
-    set req.http.x-backend-feeds = true;
-    set req.http.x-forwarded-host = std.getenv("FEEDS_HOST");
-    set req.url = "/friends.xml";
-  } else if (req.url ~ "^/rfc/feed/?(\?.*)?$") {
-    set req.backend_hint = feeds.backend(std.getenv("BACKEND_FEEDS_HOST"), std.getenv("BACKEND_FEEDS_PORT"));
-    set req.http.x-backend-fqdn = std.getenv("BACKEND_FEEDS_FQDN");
-    set req.http.x-backend-feeds = true;
-    set req.http.x-forwarded-host = std.getenv("FEEDS_HOST");
-    set req.url = "/rfc.xml";
-  } else if (req.url ~ "^/spotlight/feed/?(\?.*)?$") {
-    set req.backend_hint = feeds.backend(std.getenv("BACKEND_FEEDS_HOST"), std.getenv("BACKEND_FEEDS_PORT"));
-    set req.http.x-backend-fqdn = std.getenv("BACKEND_FEEDS_FQDN");
-    set req.http.x-backend-feeds = true;
-    set req.http.x-forwarded-host = std.getenv("FEEDS_HOST");
-    set req.url = "/spotlight.xml";
-  } else if (req.url ~ "^/afk/feed/?(\?.*)?$") {
-    set req.backend_hint = feeds.backend(std.getenv("BACKEND_FEEDS_HOST"), std.getenv("BACKEND_FEEDS_PORT"));
-    set req.http.x-backend-fqdn = std.getenv("BACKEND_FEEDS_FQDN");
-    set req.http.x-backend-feeds = true;
-    set req.http.x-forwarded-host = std.getenv("FEEDS_HOST");
-    set req.url = "/afk.xml";
-  } else if (req.url ~ "^/posts/feed/?(\?.*)?$") {
-    set req.backend_hint = feeds.backend(std.getenv("BACKEND_FEEDS_HOST"), std.getenv("BACKEND_FEEDS_PORT"));
-    set req.http.x-backend-fqdn = std.getenv("BACKEND_FEEDS_FQDN");
-    set req.http.x-backend-feeds = true;
-    set req.http.x-forwarded-host = std.getenv("FEEDS_HOST");
-    set req.url = "/posts.xml";
+  # The ++ feed is private: only reachable via its tokenized URL, which is why
+  # /plusplus.xml is deliberately NOT in the direct .xml allowlist below.
+  # The URL is only normalized here; the rewrite to /plusplus.xml happens in
+  # vcl_backend_fetch so that the token stays in the cache key & a request
+  # without the token can never hit the cached private feed.
   } else if (req.url ~ "^/plusplus/xae9heiphohtupha1Ahha3aexoo0oo4W/feed/?(\?.*)?$") {
-    set req.backend_hint = feeds.backend(std.getenv("BACKEND_FEEDS_HOST"), std.getenv("BACKEND_FEEDS_PORT"));
-    set req.http.x-backend-fqdn = std.getenv("BACKEND_FEEDS_FQDN");
+    set req.url = "/plusplus/xae9heiphohtupha1Ahha3aexoo0oo4W/feed";
     set req.http.x-backend-feeds = true;
-    set req.http.x-forwarded-host = std.getenv("FEEDS_HOST");
-    set req.url = "/plusplus.xml";
-  } else if (req.url ~ "^/rss/?(\?.*)?$") {
-    set req.backend_hint = feeds.backend(std.getenv("BACKEND_FEEDS_HOST"), std.getenv("BACKEND_FEEDS_PORT"));
-    set req.http.x-backend-fqdn = std.getenv("BACKEND_FEEDS_FQDN");
-    set req.http.x-backend-feeds = true;
-    set req.http.x-forwarded-host = std.getenv("FEEDS_HOST");
-    set req.url = "/feed.xml";
-  } else if (req.url ~ "^/feeds/.*(\?.*)?$") {
-    set req.backend_hint = feeds.backend(std.getenv("BACKEND_FEEDS_HOST"), std.getenv("BACKEND_FEEDS_PORT"));
-    set req.http.x-backend-fqdn = std.getenv("BACKEND_FEEDS_FQDN");
-    set req.http.x-backend-feeds = true;
-    set req.http.x-forwarded-host = std.getenv("FEEDS_HOST");
+  # Personal & other feeds, e.g. /feeds/<id> → /<id>.xml
+  } else if (req.url ~ "^/feeds/") {
     set req.url = regsub(req.url, "^/feeds/([^?]*)(\?.*)?$", "/\1.xml");
+    # The private ++ feed must never be reachable without its token
+    if (req.url != "/plusplus.xml") {
+      set req.http.x-backend-feeds = true;
+    }
+  # Direct requests for the canonical form, e.g. /feed.xml (old bookmarks & crawlers)
+  } else if (req.url ~ "^/(feed|podcast|gotime|master|jsparty|shipit|news|brainscience|founderstalk|interviews|friends|rfc|spotlight|afk|posts)\.xml(\?.*)?$") {
+    set req.url = regsub(req.url, "\?.*$", "");
+    set req.http.x-backend-feeds = true;
+  }
+
+  # All feed requests are served by the same FEEDS backend
+  if (req.http.x-backend-feeds) {
+    set req.backend_hint = feeds.backend(std.getenv("BACKEND_FEEDS_HOST"), std.getenv("BACKEND_FEEDS_PORT"));
+    set req.http.x-backend-fqdn = std.getenv("BACKEND_FEEDS_FQDN");
+    set req.http.x-forwarded-host = std.getenv("FEEDS_HOST");
+
+    # Feed access control is via tokenized URLs, never via credentials.
+    # Drop them so that the builtin vcl_recv does not pass these requests
+    # (they would never be served from the cache otherwise).
+    unset req.http.cookie;
+    unset req.http.authorization;
+  }
+}
+
+sub vcl_backend_fetch {
+  # The private ++ feed: the tokenized URL is the cache key (see vcl_recv);
+  # only the backend request is rewritten to the canonical form
+  if (bereq.url == "/plusplus/xae9heiphohtupha1Ahha3aexoo0oo4W/feed") {
+    set bereq.url = "/plusplus.xml";
   }
 }
 


### PR DESCRIPTION
This includes a few related changes:

1. **Cache asset responses despite credentials.** Requests carrying a `Cookie` or `Authorization` header were passed by Varnish's builtin `vcl_recv` and never cached, so a logged-in browser hit the origin for every public static file (and every feed). Both feeds and assets are public and never vary on credentials, so we unset those headers once the request is routed. Completes the v1.3 roadmap item "disable cookies for asset requests".

2. **Rework feed routing as a normalized allowlist.** Collapses the 16 blocks into one allowlist + shared backend assignment, and fixes three things that were broken behind the duplication:
  - Direct canonical URLs (`/feed.xml`, `/podcast.xml`, ...) matched no rule, fell through to the app backend, and 404'd. They are the exact URLs the aliases rewrite to internally, yet were never routable from outside. Old bookmarks and crawlers now work.
  - The private `++` feed could be reached without its token: the alias was rewritten before the cache hash, so a token-less `/plusplus.xml` (and `/feeds/plusplus`) served the cached private object. The rewrite now happens in `vcl_backend_fetch`, so the token stays in the cache key and a token-less request can never hit the cached feed.
  - The query string is dropped, so each feed is a single cache object.
  - `feeds-backend.vcl` drops from 149 to 100 lines.

3. **Add AGENTS.md to orient contributors.** A single map of Pipely: architecture, the VCL include/concatenation mechanics, the routing and credential-strip rules, observability, and the just/Dagger workflow.

4. **Log app_generation from FLY_APP_NAME.** A self-contained fix riding along: `vcl_init` read `FLY_APP`, but Fly machines expose the app name as `FLY_APP_NAME` and never set `FLY_APP`, so every machine logged the `NOW` fallback instead of the deploy generation, defeating the field added in #52.

## Testing

`just test` (VTC + local acceptance). New coverage:

- `feeds-backend.vtc`: direct `.xml` routing, query-string drop, the two `++` bypasses, client header injection.
- `plusplus.vtc`: the `++` feed is reachable only via its tokenized URL.
- `credentials.vtc`: credentialed feed and asset requests still cache.
- `feeds.hurl` / `assets.hurl`: production-shaped acceptance assertions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Ensured authenticated requests no longer force cache bypass for asset and feed content.
  * Hardened feed routing to ignore client-provided backend routing hints and enforce canonical URLs.

* **New Features**
  * Enforced token-only access for private “++” feeds (including URL normalization).
  * Improved canonical feed URL handling (query dropping and private route behavior).

* **Documentation**
  * Added an AI-agent coding guide for architecture and VCL routing rules.
  * Updated the v1.2 roadmap checklist ordering and cookie-scope.

* **Tests**
  * Expanded acceptance and VTC coverage for credential stripping, caching behavior, and routing rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->